### PR TITLE
Add the ability to mute windows when set in config

### DIFF
--- a/window-definitions.json
+++ b/window-definitions.json
@@ -9,6 +9,7 @@
   },
   {
     "url": "https://proto.utwente.nl/narrowcasting",
-    "display": 2
+    "display": 2,
+    "muted": true
   }
 ]

--- a/windowManager.js
+++ b/windowManager.js
@@ -35,6 +35,7 @@ module.exports.loadWindows = () => {
       });
 
       windows[i].webContents.session.clearCache(() => {} /*empty callback*/);
+      windows[i].webContents.setAudioMuted(windowSpec.muted || false);
       windows[i].loadURL(windowSpec.url);
       enableAdBlocker(windows[i]);
       windows[i].reload();


### PR DESCRIPTION
Adds the 'mute' attribute to the window definitions.
This allows for a tab to be permanently muted.